### PR TITLE
Fix for IE7 problem which blocks quickselect

### DIFF
--- a/quickselect/jquery.quickselect.js
+++ b/quickselect/jquery.quickselect.js
@@ -370,7 +370,7 @@ var QuickSelect;
         a = (self.options.matchCase ? self.getLabel(a) : self.getLabel(a).toLowerCase());
         b = (self.options.matchCase ? self.getLabel(b) : self.getLabel(b).toLowerCase());
         // Get proximities
-        var a_proximity = a.indexOf(match_query);
+        var a_proximity = a ? a.indexOf(match_query) : ''; // The ternary check for a is a fix for an obscure IE7 bug, where a sometimes is not set
         var b_proximity = b.indexOf(match_query);
         // Compare a & b by match proximity to beginning of label, secondly alphabetically
         return(a_proximity > b_proximity ? -1 : (a_proximity < b_proximity ? 1 : (a > b ? -1 : (b > a ? 1 : 0))));


### PR DESCRIPTION
HI dcparker.
I ran into a problem with your Quickselect plugin in IE7, where you get a JavaScript error which then blocks the autocomplete from being shown. I've fixed the problem in my fork (simple one-line fix).

Here's a page which reproduces the problem:
http://dl.dropbox.com/u/328685/temp/quickselect_ie7bug.html

Please pull - or just correct manually if you find that better, the fix is that simple.

Best,
Guðmundur
